### PR TITLE
Various improvements and bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .cache/**
 build/**
+roms/**
 compile_commands.json

--- a/src/nes/bus.cpp
+++ b/src/nes/bus.cpp
@@ -85,6 +85,10 @@ uint8_t Bus::ReadChr(uint16_t addr) {
 	return cartridge_->ReadChar(addr);
 }
 
+std::span<uint8_t> Bus::ReadChrN(uint16_t addr, uint16_t count) {
+	return cartridge_->ReadChrN(addr, count);
+}
+
 void Bus::InsertCartridge(Cartridge* cart) {
 	cartridge_ = cart;
 }

--- a/src/nes/bus.h
+++ b/src/nes/bus.h
@@ -18,6 +18,7 @@ public:
 	void Write(uint16_t addr, uint8_t val);
 
 	uint8_t ReadChr(uint16_t addr);
+	std::span<uint8_t> ReadChrN(uint16_t addr, uint16_t count);
 
 	void InsertCartridge(Cartridge* cart);
 	void AttachPPU(Ppu2C02* ppu);

--- a/src/nes/bus.h
+++ b/src/nes/bus.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <array>
+#include <span>
 
 #include "cartridge.h"
 #include "controller.h"
@@ -13,6 +14,7 @@ class Ppu2C02;
 class Bus {
 public:
 	uint8_t Read(uint16_t addr, bool silent = false);
+	std::span<uint8_t> ReadN(uint16_t addr, uint16_t count);
 	void Write(uint16_t addr, uint8_t val);
 
 	uint8_t ReadChr(uint16_t addr);

--- a/src/nes/cartridge.cpp
+++ b/src/nes/cartridge.cpp
@@ -63,6 +63,10 @@ uint8_t Cartridge::ReadChar(uint16_t addr) {
 	return mapper_->ReadChar(addr);
 }
 
+std::span<uint8_t> Cartridge::ReadChrN(uint16_t addr, uint16_t count){
+	return mapper_->ReadChrN(addr, count);
+}
+
 void Cartridge::WriteChar(uint16_t addr, uint8_t val) {
 	mapper_->WriteChar(addr, val);
 }

--- a/src/nes/cartridge.cpp
+++ b/src/nes/cartridge.cpp
@@ -51,6 +51,10 @@ uint8_t Cartridge::ReadPrg(uint16_t addr) {
 	return mapper_->ReadPrg(addr);
 }
 
+std::span<uint8_t> Cartridge::ReadPrgN(uint16_t addr, uint16_t count){
+	return mapper_->ReadPrgN(addr, count);
+}
+
 void Cartridge::WritePrg(uint16_t addr, uint8_t val) {
 	mapper_->WritePrg(addr, val);
 }

--- a/src/nes/cartridge.h
+++ b/src/nes/cartridge.h
@@ -13,6 +13,7 @@ public:
 	bool LoadFile(const std::string& filePath);
 
 	uint8_t ReadPrg(uint16_t addr);
+	std::span<uint8_t> ReadPrgN(uint16_t addr, uint16_t count);
 	void WritePrg(uint16_t addr, uint8_t val);
 	uint8_t ReadChar(uint16_t addr);
 	void WriteChar(uint16_t addr, uint8_t val);

--- a/src/nes/cartridge.h
+++ b/src/nes/cartridge.h
@@ -16,6 +16,7 @@ public:
 	std::span<uint8_t> ReadPrgN(uint16_t addr, uint16_t count);
 	void WritePrg(uint16_t addr, uint8_t val);
 	uint8_t ReadChar(uint16_t addr);
+	std::span<uint8_t> ReadChrN(uint16_t addr, uint16_t count);
 	void WriteChar(uint16_t addr, uint8_t val);
 private:
 

--- a/src/nes/cpu6502.cpp
+++ b/src/nes/cpu6502.cpp
@@ -740,7 +740,7 @@ void Cpu6502::Tick() {
 			break;
 		}
 		case Instruction::kPLP: {
-		    status_ = PopStack() & ~Flag::B | Flag::X;
+		    status_ = (PopStack() & ~Flag::B) | Flag::X;
 		    assert(op.addrMode == AddressMode::kIMP);
 		    cycleLeft_ += 4;
 		    break;
@@ -820,7 +820,7 @@ void Cpu6502::Tick() {
 			break;
 		}
 		case Instruction::kRTI: {
-		    status_ = PopStack() & ~Flag::B | Flag::X;
+		    status_ = (PopStack() & ~Flag::B) | Flag::X;
 			uint16_t addr = PopStack(); // LL
 			addr |= PopStack() << 8; // HH
 			pc_ = addr;

--- a/src/nes/mappers/mapper_mmc1.cpp
+++ b/src/nes/mappers/mapper_mmc1.cpp
@@ -91,6 +91,10 @@ uint8_t Mapper_MMC1::ReadChar(uint16_t addr) {
 	return buffer_[descriptor_.chrRomStart + addr];
 }
 
+std::span<uint8_t> Mapper_MMC1::ReadChrN(uint16_t addr, uint16_t count) {
+	return {buffer_ + descriptor_.chrRomStart + addr, count};
+}
+
 void Mapper_MMC1::WriteChar(uint16_t addr, uint8_t val) {
 	tfm::printf("ERROR: Invalid CHR write address at 0x%04X!", addr);
 	assert(false);

--- a/src/nes/mappers/mapper_mmc1.cpp
+++ b/src/nes/mappers/mapper_mmc1.cpp
@@ -43,6 +43,24 @@ uint8_t Mapper_MMC1::ReadPrg(uint16_t addr) {
 	return 0;
 }
 
+std::span<uint8_t> Mapper_MMC1::ReadPrgN(uint16_t addr, uint16_t count) {
+	uint16_t endAddr = addr + count;
+	if (IsInRange(0x6000, 0x7FFF, addr) && ramEnabled_) { // PRG RAM
+		uint16_t effAddr = addr - 0x6000;
+		return {prgRAM_.data() + effAddr, count};
+	} else if (IsInRange(0x8000, 0xBFFF, addr)) {
+		uint16_t effAddr = prgBankAddressOffsets_[0] + (addr - 0x8000);
+		return {buffer_ + effAddr, count};
+	} else if (IsInRange(0xC000, 0xFFFF, addr)) {
+		uint16_t effAddr = prgBankAddressOffsets_[1] + (addr - 0xC000);
+		return {buffer_ + effAddr, count};
+	}
+
+	tfm::printf("ERROR: Invalid PRG-N read address at 0x%04X!", addr);
+	assert(false);
+	return {};
+}
+
 void Mapper_MMC1::WritePrg(uint16_t addr, uint8_t val) {
 	if (IsInRange(0x6000, 0x7FFF, addr) && ramEnabled_) { // PRG RAM
 		prgRAM_[addr - 0x6000] = val;

--- a/src/nes/mappers/mapper_mmc1.h
+++ b/src/nes/mappers/mapper_mmc1.h
@@ -11,6 +11,7 @@ public:
 	virtual const std::string& GetName() override;
 	virtual uint16_t GetId() override;
 	virtual uint8_t ReadPrg(uint16_t addr) override;
+	virtual std::span<uint8_t> ReadPrgN(uint16_t addr, uint16_t count) override;
 	virtual void WritePrg(uint16_t addr, uint8_t val) override;
 	virtual uint8_t ReadChar(uint16_t addr) override;
 	virtual void WriteChar(uint16_t addr, uint8_t val) override;

--- a/src/nes/mappers/mapper_mmc1.h
+++ b/src/nes/mappers/mapper_mmc1.h
@@ -14,6 +14,7 @@ public:
 	virtual std::span<uint8_t> ReadPrgN(uint16_t addr, uint16_t count) override;
 	virtual void WritePrg(uint16_t addr, uint8_t val) override;
 	virtual uint8_t ReadChar(uint16_t addr) override;
+	virtual std::span<uint8_t> ReadChrN(uint16_t addr, uint16_t count) override;
 	virtual void WriteChar(uint16_t addr, uint8_t val) override;
 private:
 	bool ramEnabled_ = true;

--- a/src/nes/mappers/mapper_nrom.cpp
+++ b/src/nes/mappers/mapper_nrom.cpp
@@ -40,6 +40,25 @@ uint8_t Mapper_NROM::ReadPrg(uint16_t addr) {
 	return 0;
 }
 
+std::span<uint8_t> Mapper_NROM::ReadPrgN(uint16_t addr, uint16_t count) {
+	if (IsInRange(0x8000, 0xBFFF, addr)) {
+		auto effAddr = descriptor_.prgRomStart + addr - 0x8000;
+		return {buffer_ + effAddr, count};
+	}
+	if (IsInRange(0xC000, 0xFFFF, addr)) {
+		if (descriptor_.prgRomSize > 0x4000) {
+			auto effAddr = descriptor_.prgRomStart + (addr - 0x8000);
+			return {buffer_ + effAddr, count};
+		} else {
+			auto effAddr = descriptor_.prgRomStart + (addr - 0xC000);
+			return {buffer_ + effAddr, count};
+		}
+	}
+
+	assert(false);
+	return {};
+}
+
 void Mapper_NROM::WritePrg(uint16_t addr, uint8_t val) {
 	tfm::printf("ERROR: Invalid PRG write address at 0x%04X!", addr);
 	assert(false);

--- a/src/nes/mappers/mapper_nrom.cpp
+++ b/src/nes/mappers/mapper_nrom.cpp
@@ -68,6 +68,10 @@ uint8_t Mapper_NROM::ReadChar(uint16_t addr) {
 	return buffer_[descriptor_.chrRomStart + addr];
 }
 
+std::span<uint8_t> Mapper_NROM::ReadChrN(uint16_t addr, uint16_t count) {
+	return {buffer_ + descriptor_.chrRomStart + addr, count};
+}
+
 void Mapper_NROM::WriteChar(uint16_t addr, uint8_t val) {
 	tfm::printf("ERROR: Invalid CHR write address at 0x%04X!", addr);
 	assert(false);

--- a/src/nes/mappers/mapper_nrom.h
+++ b/src/nes/mappers/mapper_nrom.h
@@ -13,6 +13,7 @@ public:
 	virtual std::span<uint8_t> ReadPrgN(uint16_t addr, uint16_t count) override;
 	virtual void WritePrg(uint16_t addr, uint8_t val) override;
 	virtual uint8_t ReadChar(uint16_t addr) override;
+	virtual std::span<uint8_t> ReadChrN(uint16_t addr, uint16_t count) override;
 	virtual void WriteChar(uint16_t addr, uint8_t val) override;
 private:
 };

--- a/src/nes/mappers/mapper_nrom.h
+++ b/src/nes/mappers/mapper_nrom.h
@@ -10,6 +10,7 @@ public:
 	virtual const std::string& GetName() override;
 	virtual uint16_t GetId() override;
 	virtual uint8_t ReadPrg(uint16_t addr) override;
+	virtual std::span<uint8_t> ReadPrgN(uint16_t addr, uint16_t count) override;
 	virtual void WritePrg(uint16_t addr, uint8_t val) override;
 	virtual uint8_t ReadChar(uint16_t addr) override;
 	virtual void WriteChar(uint16_t addr, uint8_t val) override;

--- a/src/nes/mappers/mapperbase.h
+++ b/src/nes/mappers/mapperbase.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <string>
+#include <span>
 
 namespace nes::mapper {
 
@@ -15,6 +16,7 @@ public:
 	virtual const std::string& GetName() = 0;
 	virtual uint16_t GetId() = 0;
 	virtual uint8_t ReadPrg(uint16_t addr) = 0;
+	virtual std::span<uint8_t> ReadPrgN(uint16_t addr, uint16_t count) = 0;
 	virtual void WritePrg(uint16_t addr, uint8_t val) = 0;
 	virtual uint8_t ReadChar(uint16_t addr) = 0;
 	virtual void WriteChar(uint16_t addr, uint8_t val) = 0;

--- a/src/nes/mappers/mapperbase.h
+++ b/src/nes/mappers/mapperbase.h
@@ -19,6 +19,7 @@ public:
 	virtual std::span<uint8_t> ReadPrgN(uint16_t addr, uint16_t count) = 0;
 	virtual void WritePrg(uint16_t addr, uint8_t val) = 0;
 	virtual uint8_t ReadChar(uint16_t addr) = 0;
+	virtual std::span<uint8_t> ReadChrN(uint16_t addr, uint16_t count) = 0;
 	virtual void WriteChar(uint16_t addr, uint8_t val) = 0;
 
 protected:

--- a/src/nes/ppu.cpp
+++ b/src/nes/ppu.cpp
@@ -522,12 +522,21 @@ void Ppu2C02::DrawSpriteLayer() {
 
 uint8_t Ppu2C02::GetPaletteIdx(uint16_t attrTableBase, uint8_t row, uint8_t col) {
 	auto attr = vramStorage_[attrTableBase + (row / 4) * 8 + (col / 4)];
-	auto tmp = ((row & 1) << 1) | (col & 1);
-	switch (tmp) {
-		case 0: return attr  & 0x03;
-		case 1: return (attr & 0x0C) >> 2;
-		case 2: return (attr & 0x30) >> 4;
-		case 3: return (attr & 0xC0) >> 6;
+	auto id = ((row & 1) << 1) | (col & 1);
+	//
+	//   -----------
+	//  | r0  | r0  |
+	//  | c0  | c1  |
+	//  |-----------|
+	//  | r1  | r1  |
+	//  | c0  | c1  |
+	//   -----------
+	//
+	switch (id) {
+		case 0b00: return attr  & 0x03;
+		case 0b01: return (attr & 0x0C) >> 2;
+		case 0b10: return (attr & 0x30) >> 4;
+		case 0b11: return (attr & 0xC0) >> 6;
 		default: {
 			assert(false);
 			return 0;

--- a/src/nes/ppu.cpp
+++ b/src/nes/ppu.cpp
@@ -97,7 +97,7 @@ uint8_t Ppu2C02::Read(uint16_t addr, bool silent) {
 			    status_ &= 0x7F;
 
 			    vramBuffer_ = 0;
-			    scrollBuffer_ = 0;
+			    scrollBuffer_ = {0, 0};
 			}
 
 			return tmp;
@@ -152,8 +152,8 @@ void Ppu2C02::Write(uint16_t addr, uint8_t val) {
 			break;
 		}
 		case kPPUSCROLL: {
-			scrollBuffer_ <<= 8;
-			scrollBuffer_ |= val;
+			scrollBuffer_[scrollSetIndex_] = val;
+			scrollSetIndex_ ^= 1;
 			break;
 		}
 		case kPPUADDR: {

--- a/src/nes/ppu.cpp
+++ b/src/nes/ppu.cpp
@@ -412,14 +412,17 @@ void Ppu2C02::DrawBackgroundLayers() {
 	for (int bufIdx = 0; bufIdx < 2; ++bufIdx) {
 		auto& bgBuffer = backgroundBuffers_[bufIdx];
 		memset(bgBuffer.data(), 0, bgBuffer.size() * sizeof(BufferDot));
-		const uint16_t attrTableBase =
-		    kNameTableStart[bufIdx] - kNameTableStart[0] + 0x3C0;
+
+		const uint16_t nameTableBase = kNameTableStart[bufIdx] - kNameTableStart[0];
+		const uint16_t attrTableBase = nameTableBase + 0x3C0;
 
 		for (int row = 0; row < 30; ++row) {
 			for (int col = 0; col < 32; ++col) {
-				auto idx = (kNameTableStart[bufIdx] - kNameTableStart[0]) + row * 32 + col;
+				auto idx = nameTableBase + row * 32 + col;
 				auto patternIdx = vramStorage_[idx];
-				auto patternStartAddr = controlState_.backgroundTableIdx*0x1000 + patternIdx * 16;
+				auto patternStartAddr =
+				    controlState_.backgroundTableIdx * 0x1000 +
+				    patternIdx * 16;
 
 				t.FromData(bus_->ReadChrN(patternStartAddr, 16));
 
@@ -489,13 +492,14 @@ void Ppu2C02::DrawSpriteLayer() {
 
 uint8_t Ppu2C02::GetPaletteIdx(uint16_t attrTableBase, uint8_t row, uint8_t col) {
 	auto attr = vramStorage_[attrTableBase + (row / 4) * 8 + (col / 4)];
-	auto tmp = ((row % 2) << 1) & (col % 2);
+	auto tmp = ((row & 1) << 1) | (col & 1);
 	switch (tmp) {
-		case 0: return attr & 0x03;
+		case 0: return attr  & 0x03;
 		case 1: return (attr & 0x0C) >> 2;
 		case 2: return (attr & 0x30) >> 4;
 		case 3: return (attr & 0xC0) >> 6;
 		default: {
+			assert(false);
 			return 0;
 		}
 	}

--- a/src/nes/ppu.cpp
+++ b/src/nes/ppu.cpp
@@ -250,7 +250,9 @@ void Ppu2C02::Tick() {
 
 	    auto spriteDot = spriteBuffer_[dstIdx];
 	    if (spriteDot.color.a != 0 && spriteDot.isOpaque) {
-			frameBuffer_[dstIdx] = spriteDot.color;
+			if (!spriteDot.isBehind || !bgDot.isOpaque) {
+			    frameBuffer_[dstIdx] = spriteDot.color;
+			}
 
 			if (bgDot.isOpaque && spriteDot.isSprite0 &&
 				!spriteZeroReported_) {
@@ -514,7 +516,7 @@ void Ppu2C02::DrawSpriteLayer() {
 				continue;
 			}
 
-			spriteBuffer_[idx] = {c, isOpaque, i == 0};
+			spriteBuffer_[idx] = {c, isOpaque, (entry.attr & 0x20) != 0, i == 0};
 		}
 	}
 

--- a/src/nes/ppu.cpp
+++ b/src/nes/ppu.cpp
@@ -130,6 +130,12 @@ uint8_t Ppu2C02::Read(uint16_t addr, bool silent) {
 
 std::span<uint8_t> Ppu2C02::ReadN(uint16_t addr, uint16_t count) {
 	switch (addr) {
+		case 0x0000: { // Nametable0
+			return {vramStorage_.data(), kNameTableSize};
+		}
+		case 0x1000: { // Nametable1
+			return {vramStorage_.data() + kNameTableSize, kNameTableSize};
+		}
 		case kOAMDATA: {
 			return {oamStorage_.data() + oamAddress_, count};
 		}

--- a/src/nes/ppu.cpp
+++ b/src/nes/ppu.cpp
@@ -128,6 +128,17 @@ uint8_t Ppu2C02::Read(uint16_t addr, bool silent) {
 	return 0;
 }
 
+std::span<uint8_t> Ppu2C02::ReadN(uint16_t addr, uint16_t count) {
+	switch (addr) {
+		case kOAMDATA: {
+			return {oamStorage_.data() + oamAddress_, count};
+		}
+	}
+
+	assert(false);
+	return {};
+}
+
 void Ppu2C02::Write(uint16_t addr, uint8_t val) {
 	//tfm::printf("PPU write %s (0x%04X) -> 0x%02X\n", AddressToString(addr), addr, val);
 	switch (addr) {

--- a/src/nes/ppu.cpp
+++ b/src/nes/ppu.cpp
@@ -456,9 +456,11 @@ void Ppu2C02::DrawBackgroundLayers() {
 
 				auto paletteIdx = GetPaletteIdx(attrTableBase, row, col);
 				for (int i = 0; i < 8*8; ++i) {
-					auto colorIdx = framePalette_[paletteIdx][t.data[i]];
+					auto pxColorIdx = t.data[i];
+					// Pal0 contains global bg color
+					auto colorIdx = framePalette_[pxColorIdx ? paletteIdx : 0][pxColorIdx];
 					bgBuffer[(row * 8 + i / 8) * 256 + col * 8 + i % 8] = {
-						kColorPalette[colorIdx], t.data[i] != 0, false};
+						kColorPalette[colorIdx], pxColorIdx != 0, false};
 				}
 			}
 		}

--- a/src/nes/ppu.cpp
+++ b/src/nes/ppu.cpp
@@ -36,6 +36,7 @@ constexpr uint16_t kPPUDATA = 0x2007;   // READ/WRITE
 constexpr std::array<uint16_t, 2> kPatternTableStart = {0x0000, 0x1000};
 constexpr std::array<uint16_t, 4> kNameTableStart = {0x2000, 0x2400, 0x2800, 0x2C00};
 constexpr uint16_t kPaletteTableStart = 0x3F00;
+constexpr uint16_t kNameTableSize = 0x03FF;
 
 struct OAMEntry {
 	uint8_t y;
@@ -287,23 +288,23 @@ uint8_t Ppu2C02::HandleDataRead(bool silent) {
 	}
 
 	// Nametable 0
-	if (IsInRange(kNameTableStart[0], kNameTableStart[0] + 0x03FF, addr)) {
+	if (IsInRange(kNameTableStart[0], kNameTableStart[0] + kNameTableSize, addr)) {
 		result = vramStorage_[addr - kNameTableStart[0]];
 	}
 
 	// Nametable 1
-	if (IsInRange(kNameTableStart[1], kNameTableStart[1] + 0x03FF, addr)) {
-		result = vramStorage_[addr - kNameTableStart[1]];
+	if (IsInRange(kNameTableStart[1], kNameTableStart[1] + kNameTableSize, addr)) {
+		result = vramStorage_[addr - kNameTableStart[0]];
 	}
 
 	// Nametable 2
-	if (IsInRange(kNameTableStart[2], kNameTableStart[2] + 0x03FF, addr)) {
+	if (IsInRange(kNameTableStart[2], kNameTableStart[2] + kNameTableSize, addr)) {
 		// TODO
 		result = 0;
 	}
 
 	// Nametable 3
-	if (IsInRange(kNameTableStart[3], kNameTableStart[3] + 0x03FF, addr)) {
+	if (IsInRange(kNameTableStart[3], kNameTableStart[3] + kNameTableSize, addr)) {
 		// TODO
 		result = 0;
 	}
@@ -347,22 +348,22 @@ void Ppu2C02::HandleDataWrite(uint8_t val) {
 	}
 
 	// Nametable 0
-	if (IsInRange(kNameTableStart[0], kNameTableStart[0] + 0x03FF, addr)) {
+	if (IsInRange(kNameTableStart[0], kNameTableStart[0] + kNameTableSize, addr)) {
 		vramStorage_[addr - kNameTableStart[0]] = val;
 	}
 
 	// Nametable 1
-	if (IsInRange(kNameTableStart[1], kNameTableStart[1] + 0x03FF, addr)) {
-		vramStorage_[addr - kNameTableStart[1]] = val;
+	if (IsInRange(kNameTableStart[1], kNameTableStart[1] + kNameTableSize, addr)) {
+		vramStorage_[addr - kNameTableStart[0]] = val;
 	}
 
 	// Nametable 2
-	if (IsInRange(kNameTableStart[2], kNameTableStart[2] + 0x03FF, addr)) {
+	if (IsInRange(kNameTableStart[2], kNameTableStart[2] + kNameTableSize, addr)) {
 		// TODO
 	}
 
 	// Nametable 3
-	if (IsInRange(kNameTableStart[3], kNameTableStart[3] + 0x03FF, addr)) {
+	if (IsInRange(kNameTableStart[3], kNameTableStart[3] + kNameTableSize, addr)) {
 		// TODO
 	}
 

--- a/src/nes/ppu.cpp
+++ b/src/nes/ppu.cpp
@@ -474,7 +474,7 @@ void Ppu2C02::DrawSpriteLayer() {
 	memset(spriteBuffer_.data(), 0, spriteBuffer_.size() * sizeof(BufferDot));
 	memset(spriteZeroData_.data(), 0, spriteZeroData_.size() * sizeof(RGBA));
 	auto* entries = reinterpret_cast<OAMEntry*>(oamStorage_.data());
-	for (int i = 0; i < 64; ++i) {
+	for (int i = 63; i >= 0; --i) {
 		auto& entry = entries[i];
 		if (entry.y >= 0xEF || entry.x >= 240) {
 			continue;

--- a/src/nes/ppu.cpp
+++ b/src/nes/ppu.cpp
@@ -330,19 +330,33 @@ uint8_t Ppu2C02::HandleDataRead(bool silent) {
 		result = 0;
 	}
 
-	// Mirror 0x3F00-0x3F1F
-	if (IsInRange(0x3F20, 0x3FFF, addr)) {
-		addr = ((addr - 0x3F20) % 0x20) + kPaletteTableStart;
-	}
 	// Palette indexes
-	if (IsInRange(kPaletteTableStart, kPaletteTableStart + 0x0020, addr)) {
+	if (IsInRange(kPaletteTableStart + 0x0020, 0x3FFF, addr)) {
+		addr = kPaletteTableStart + ((addr - kPaletteTableStart) % 0x0020);
+	}
+
+	if (IsInRange(kPaletteTableStart, kPaletteTableStart + 0x001F, addr)) {
+		switch (addr) {
+			case 0x3F10:
+				addr = 0x3F00;
+				break;
+			case 0x3F14:
+				addr = 0x3F04;
+				break;
+			case 0x3F18:
+				addr = 0x3F08;
+				break;
+			case 0x3F1C:
+				addr = 0x3F0C;
+				break;
+		}
 		auto idx = addr - kPaletteTableStart;
 		auto palIdx = idx / 4;
 		auto colorIdx = idx % 4;
 		result = framePalette_[palIdx][colorIdx];
 	}
 
-	if (IsInRange(kPaletteTableStart, kPaletteTableStart + 0x00FF, addr)) {
+	if (IsInRange(kPaletteTableStart, kPaletteTableStart + 0x001F, addr)) {
 		vramBuffer_ = result ;
 	}
 
@@ -388,12 +402,26 @@ void Ppu2C02::HandleDataWrite(uint8_t val) {
 		// TODO
 	}
 
-	// Mirror 0x3F00-0x3F1F
-	if (IsInRange(0x3F20, 0x3FFF, addr)) {
-		addr = ((addr - 0x3F20) % 0x20) + kPaletteTableStart;
-	}
 	// Palette indexes
-	if (IsInRange(kPaletteTableStart, kPaletteTableStart + 0x0020, addr)) {
+	if (IsInRange(kPaletteTableStart + 0x0020, 0x3FFF, addr)) {
+		addr = kPaletteTableStart + ((addr - kPaletteTableStart) % 0x0020);
+	}
+
+	if (IsInRange(kPaletteTableStart, kPaletteTableStart + 0x001F, addr)) {
+		switch (addr) {
+			case 0x3F10:
+				addr = 0x3F00;
+				break;
+			case 0x3F14:
+				addr = 0x3F04;
+				break;
+			case 0x3F18:
+				addr = 0x3F08;
+				break;
+			case 0x3F1C:
+				addr = 0x3F0C;
+				break;
+		}
 		auto idx = addr - kPaletteTableStart;
 		auto palIdx = idx / 4;
 		auto colorIdx = idx % 4;

--- a/src/nes/ppu.h
+++ b/src/nes/ppu.h
@@ -61,7 +61,7 @@ private:
 	struct ControlState {
 		uint16_t nameTableId = 0;
 		uint16_t spriteTableAddr;
-		uint16_t backgroundTableAddr;
+		uint16_t backgroundTableIdx = 0;
 		uint16_t addressIncrement = 0;
 		enum SpriteSize {
 			k8x8,
@@ -92,7 +92,7 @@ private:
 	uint8_t HandleDataRead(bool silent);
 	void HandleDataWrite(uint8_t val);
 
-	void FetchPattern(uint16_t nameTableBase, uint8_t row, uint8_t col);
+	void FetchPattern(uint8_t nameTableIdx, uint8_t row, uint8_t col);
 	uint8_t GetPaletteIdx(uint16_t attrTableBase, uint8_t row, uint8_t col);
 	void DrawBackgroundLayers();
 	void DrawSpriteLayer();

--- a/src/nes/ppu.h
+++ b/src/nes/ppu.h
@@ -26,15 +26,16 @@ public:
 
 	void Tick();
 private:
-	Bus* bus_ = nullptr;
-	RGBA* frameBuffer_ = nullptr;
-
 	struct BufferDot {
 		RGBA color;
 		bool isOpaque = true;
 		bool isSprite0 = false;
 	};
 	using BackingBuffer = std::array<BufferDot, kScreenColCount * kScreenRowCount>;
+
+	Bus* bus_ = nullptr;
+	RGBA* frameBuffer_ = nullptr;
+
 	std::array<BackingBuffer, 4> backgroundBuffers_;
 	BackingBuffer spriteBuffer_;
 	bool spriteZeroReported_ = false;

--- a/src/nes/ppu.h
+++ b/src/nes/ppu.h
@@ -94,7 +94,6 @@ private:
 	uint8_t HandleDataRead(bool silent);
 	void HandleDataWrite(uint8_t val);
 
-	void FetchPattern(uint8_t nameTableIdx, uint8_t row, uint8_t col);
 	uint8_t GetPaletteIdx(uint16_t attrTableBase, uint8_t row, uint8_t col);
 	void DrawBackgroundLayers();
 	void DrawSpriteLayer();

--- a/src/nes/ppu.h
+++ b/src/nes/ppu.h
@@ -31,6 +31,7 @@ private:
 	struct BufferDot {
 		RGBA color;
 		bool isOpaque = true;
+		bool isBehind = false;
 		bool isSprite0 = false;
 	};
 	using BackingBuffer = std::array<BufferDot, kScreenColCount * kScreenRowCount>;

--- a/src/nes/ppu.h
+++ b/src/nes/ppu.h
@@ -51,7 +51,8 @@ private:
 
 	std::array<uint8_t, 16> rawTileBuffer_;
 
-	uint16_t scrollBuffer_ = 0;
+	uint8_t scrollSetIndex_ = 0;
+	std::array<uint8_t, 2> scrollBuffer_{0, 0}; // X, Y
 	uint8_t status_ = 0;
 
 	uint32_t dotIdx_ = 0;

--- a/src/nes/ppu.h
+++ b/src/nes/ppu.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <array>
 #include <vector>
+#include <span>
 
 #include "palette.h"
 
@@ -17,6 +18,7 @@ public:
 	Ppu2C02(Bus* bus);
 
 	uint8_t Read(uint16_t addr, bool silent);
+	std::span<uint8_t> ReadN(uint16_t addr, uint16_t count);
 	void Write(uint16_t addr, uint8_t val);
 
 	void SetFramebuffer(RGBA* buf);


### PR DESCRIPTION
- Fixed an issue that caused inconsistent state register value after `PLP` and `RTI`
- Added `roms` folder under .gitignore
- Scrollbuffer handles both X and Y offsets
- Added `ReadN` functions to make reading memory ranges more convenient
- Hacky semi-fixes for nametable switching and attribute table reading
- Fixed a memory mirroring issue related to palette reading/writing
- Fixed Sprite0 detection in case sprites overlap
- Fixed global background color usage
- OAM priority flag is taken into consideration during rendering